### PR TITLE
Add option to use Criterion change estimates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
 name = "bstr"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -61,7 +67,7 @@ version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "strsim",
  "textwrap",
  "unicode-width",
@@ -79,10 +85,27 @@ dependencies = [
  "serde_json",
  "statrs",
  "tabwriter",
+ "tempfile",
  "termcolor",
  "unicode-width",
  "walkdir",
 ]
+
+[[package]]
+name = "errno"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fnv"
@@ -98,7 +121,19 @@ checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -153,6 +188,12 @@ name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "log"
@@ -244,6 +285,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,6 +324,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,7 +356,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -350,6 +403,19 @@ name = "regex-syntax"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
+
+[[package]]
+name = "rustix"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+dependencies = [
+ "bitflags 2.9.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "ryu"
@@ -472,6 +538,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -524,6 +603,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "wide"
 version = "0.7.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -563,6 +651,168 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.9.1",
+]
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,5 +35,8 @@ version = "2.32.0"
 default-features = false
 features = ["suggestions"]
 
+[dev-dependencies]
+tempfile = "3"
+
 [profile.release]
 debug = true

--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ When exactly two baselines are compared, `critcmp` also computes a two-tailed
 Welch t-test and reports the resulting p-value to help assess statistical
 significance of the timing difference.
 
+If Criterion has already computed change estimates for your benchmarks, you can
+use them directly instead of having `critcmp` recompute differences. This is
+done with the `--use-critcmp-change-estimate` flag, which reads the
+`change/estimates.json` file emitted by Criterion and reports the median
+change.
+
 Filtering can be done with the -f/--filter flag to limit comparisons based on
 a regex:
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -186,6 +186,10 @@ impl Args {
         Ok(Some(percent.parse()?))
     }
 
+    pub fn use_change_estimate(&self) -> bool {
+        self.0.is_present("use-critcmp-change-estimate")
+    }
+
     pub fn baselines(&self) -> bool {
         self.0.is_present("baselines")
     }
@@ -300,6 +304,10 @@ fn app() -> App<'static, 'static> {
                    this percentage are not shown. By default, all comparisons \
                    are shown. Example use: '-t 5' hides any comparisons with \
                    differences under 5%."))
+        .arg(Arg::with_name("use-critcmp-change-estimate")
+            .long("use-critcmp-change-estimate")
+            .help("Use Criterion's change/estimates.json for comparisons and \
+                   output the median change."))
         .arg(Arg::with_name("color")
             .long("color")
             .takes_value(true)

--- a/src/data.rs
+++ b/src/data.rs
@@ -29,6 +29,8 @@ pub struct Benchmark {
     pub info: CBenchmark,
     #[serde(rename = "criterion_estimates_v1")]
     pub estimates: CEstimates,
+    #[serde(skip)]
+    pub change: Option<CEstimates>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -141,8 +143,13 @@ impl Benchmark {
 
         let info = CBenchmark::from_path(parent.join("benchmark.json"))?;
         let estimates = CEstimates::from_path(path)?;
+        let change_path =
+            parent.parent().map(|p| p.join("change/estimates.json"));
+        let change = change_path
+            .filter(|p| p.exists())
+            .and_then(|p| CEstimates::from_path(p).ok());
         let fullname = format!("{}/{}", baseline, info.full_id);
-        Ok(Some(Benchmark { baseline, fullname, info, estimates }))
+        Ok(Some(Benchmark { baseline, fullname, info, estimates, change }))
     }
 
     pub fn nanoseconds(&self) -> f64 {
@@ -172,6 +179,10 @@ impl Benchmark {
 
     pub fn benchmark_name(&self) -> &str {
         &self.info.full_id
+    }
+
+    pub fn median_change(&self) -> Option<f64> {
+        self.change.as_ref().map(|c| c.median.point_estimate)
     }
 
     pub fn throughput(&self) -> Option<Throughput> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,25 @@ fn try_main() -> Result<()> {
     let args = Args::parse();
     let benchmarks = args.benchmarks()?;
 
+    if args.use_change_estimate() {
+        let mut changes = BTreeMap::new();
+        for base in benchmarks.by_baseline.values() {
+            for (name, bench) in &base.benchmarks {
+                if let Some(median) = bench.median_change() {
+                    changes.entry(name.clone()).or_insert(median);
+                }
+            }
+        }
+        if changes.is_empty() {
+            fail!("no change estimates found");
+        }
+        let mut stdout = io::stdout();
+        for (name, change) in changes {
+            writeln!(stdout, "{}\t{}", name, change)?;
+        }
+        return Ok(());
+    }
+
     if args.baselines() {
         let mut stdout = io::stdout();
         for baseline in benchmarks.by_baseline.keys() {

--- a/tests/change_estimate.rs
+++ b/tests/change_estimate.rs
@@ -1,0 +1,56 @@
+use std::fs;
+use std::process::Command;
+
+#[test]
+fn reports_median_change_from_change_estimates(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let dir = tempfile::tempdir()?;
+    let criterion = dir.path().join("criterion");
+    let bench_dir = criterion.join("group").join("bench");
+    let before_dir = bench_dir.join("before");
+    fs::create_dir_all(&before_dir)?;
+    fs::write(
+        before_dir.join("benchmark.json"),
+        r#"{
+    "group_id":"group",
+    "function_id":null,
+    "value_str":null,
+    "throughput":null,
+    "full_id":"bench",
+    "directory_name":"bench"
+}"#,
+    )?;
+    fs::write(
+        before_dir.join("estimates.json"),
+        r#"{
+    "mean":{"confidence_interval":{"confidence_level":0.95,"lower_bound":1.0,"upper_bound":1.0},"point_estimate":1.0,"standard_error":0.0},
+    "median":{"confidence_interval":{"confidence_level":0.95,"lower_bound":1.0,"upper_bound":1.0},"point_estimate":1.0,"standard_error":0.0},
+    "median_abs_dev":{"confidence_interval":{"confidence_level":0.95,"lower_bound":0.0,"upper_bound":0.0},"point_estimate":0.0,"standard_error":0.0},
+    "slope":null,
+    "std_dev":{"confidence_interval":{"confidence_level":0.95,"lower_bound":0.0,"upper_bound":0.0},"point_estimate":0.0,"standard_error":0.0}
+}"#,
+    )?;
+    let change_dir = bench_dir.join("change");
+    fs::create_dir_all(&change_dir)?;
+    fs::write(
+        change_dir.join("estimates.json"),
+        r#"{
+    "mean":{"confidence_interval":{"confidence_level":0.95,"lower_bound":1.0,"upper_bound":1.0},"point_estimate":1.0,"standard_error":0.0},
+    "median":{"confidence_interval":{"confidence_level":0.95,"lower_bound":1.0,"upper_bound":1.0},"point_estimate":1.23,"standard_error":0.0},
+    "median_abs_dev":{"confidence_interval":{"confidence_level":0.95,"lower_bound":0.0,"upper_bound":0.0},"point_estimate":0.0,"standard_error":0.0},
+    "slope":null,
+    "std_dev":{"confidence_interval":{"confidence_level":0.95,"lower_bound":0.0,"upper_bound":0.0},"point_estimate":0.0,"standard_error":0.0}
+}"#,
+    )?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_critcmp"))
+        .arg("--use-critcmp-change-estimate")
+        .arg("--target-dir")
+        .arg(dir.path())
+        .output()?;
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout)?;
+    assert!(stdout.contains("bench"));
+    assert!(stdout.contains("1.23"));
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add `--use-critcmp-change-estimate` flag to read Criterion's `change/estimates.json`
- parse and expose median change values when requested
- document new mode and cover with integration test

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689b77a4935c832891095dbfb872e9bc